### PR TITLE
gitIgnore IntelliJ fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ gradle-app.setting
 
 
 # IntelliJ IDEA iml-files
-.iml
+*.xml
+*.iml
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839


### PR DESCRIPTION
just ignoring iml and xml files since we are using gradle. they are not important, and should be user specific.